### PR TITLE
Add Physics Girl to Science & Mathematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@
 | 3Blue1Brown  | 7.4M  | English | [Visit Channel](https://www.youtube.com/c/3blue1brown) |
 | MinutePhysics  | 5.7M  | English | [Visit Channel](https://www.youtube.com/c/minutephysics) |
 | Numberphile  | 4.56M  | English | [Visit Channel](https://www.youtube.com/c/numberphile) |
+| Physics Girl  | 3.5M  | English | [Visit Channel](https://www.youtube.com/@physicsgirl) |
 | Brian McLogan  | 1.6M  | English | [Visit Channel](https://www.youtube.com/c/brianmclogan) |
 | Bozeman Science  | 1.4M  | English | [Visit Channel](https://www.youtube.com/c/baborscience) |
 | Physics Videos by Eugene Khutoryansky  | 1M  | English | [Visit Channel](https://www.youtube.com/c/EugeneKhutoryansky) |


### PR DESCRIPTION
## Summary

Adds **Physics Girl** (Dianna Cowern) to the **Science & Mathematics** category.

| Channel | Subscribers | Language | Link |
|---|---|---|---|
| Physics Girl | ~3.5M | English | https://www.youtube.com/@physicsgirl |

Physics Girl makes physics and science accessible through experiments and clear explanations.

## Changes
- Added Physics Girl row, placed by subscriber rank between Numberphile (4.56M) and Brian McLogan (1.6M)
- Channels badge/stat: 181 → 182

## Checklist
- [x] Channel is educational and free
- [x] Subscriber count verified (current, ~3.5M)
- [x] Correct language and working channel link