### PR TITLE
Add Hannah Fry to Science & Mathematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,5 +270,6 @@
 | Numberphile  | 4.56M  | English | [Visit Channel](https://www.youtube.com/c/numberphile) |
 | Brian McLogan  | 1.6M  | English | [Visit Channel](https://www.youtube.com/c/brianmclogan) |
 | Bozeman Science  | 1.4M  | English | [Visit Channel](https://www.youtube.com/c/baborscience) |
+| Hannah Fry  | 1.24M  | English | [Visit Channel](https://www.youtube.com/@fryrsquared) |
 | Physics Videos by Eugene Khutoryansky  | 1M  | English | [Visit Channel](https://www.youtube.com/c/EugeneKhutoryansky) |
 | Mathologer  | 962K  | English | [Visit Channel](https://www.youtube.com/c/Mathologer) |


### PR DESCRIPTION
## Summary

Adds **Hannah Fry** to the **Science & Mathematics** category.

| Channel | Subscribers | Language | Link |
|---|---|---|---|
| Hannah Fry | ~1.24M | English | https://www.youtube.com/@fryrsquared |

Hannah Fry is a mathematician and science communicator covering mathematics, data, and probability in everyday life.

## Changes
- Added Hannah Fry row, placed by subscriber rank between Bozeman Science (1.4M) and Physics Videos by Eugene Khutoryansky (1M)
- Channels badge/stat: 181 → 182

## Checklist
- [x] Channel is educational and free
- [x] Subscriber count verified (current, ~1.24M)
- [x] Correct language and working channel link