### PR TITLE
Add The Pragmatic Engineer to Programming & Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | LearnCode.academy  | 750K  | English | [Visit Channel](https://www.youtube.com/c/learncodeacademy) |
 | Hitesh Choudhary  | 700K  | Hindi | [Visit Channel](https://www.youtube.com/c/HiteshChoudharydotcom) |
 | Java Brains  | 565K  | English | [Visit Channel](https://www.youtube.com/c/JavaBrainsChannel) |
+| The Pragmatic Engineer  | 500K  | English | [Visit Channel](https://www.youtube.com/@ThePragmaticEngineer) |
 | Coding with John  | 485K  | English | [Visit Channel](https://www.youtube.com/c/CodingwithJohn) |
 | The Cherno  | 485K  | English | [Visit Channel](https://www.youtube.com/c/TheChernoProject) |
 | LevelUpTuts  | 340K  | English | [Visit Channel](https://www.youtube.com/c/LevelUpTuts) |


### PR DESCRIPTION
## Summary

Adds **The Pragmatic Engineer** (Gergely Orosz) to the **Programming & Coding** category.

| Channel | Subscribers | Language | Link |
|---|---|---|---|
| The Pragmatic Engineer | ~500K | English | https://www.youtube.com/@ThePragmaticEngineer |

The Pragmatic Engineer features in-depth interviews and content on software engineering, Big Tech, and career growth from the author of the #1 software engineering newsletter.

## Changes
- Added The Pragmatic Engineer row, placed by subscriber rank between Java Brains (565K) and Coding with John (485K)
- Channels badge/stat: 181 → 182

## Checklist
- [x] Channel is educational and free
- [x] Subscriber count verified (current, ~500K)
- [x] Correct language and working channel link