### PR TITLE
Add LaurieWired to Cybersecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@
 | Hak5  | 800K  | English | [Visit Channel](https://www.youtube.com/c/Hak5) |
 | Null Byte  | 600K  | English | [Visit Channel](https://www.youtube.com/c/NullByteWHT) |
 | IppSec  | 400K  | English | [Visit Channel](https://www.youtube.com/c/ippsec) |
+| LaurieWired  | 429K  | English | [Visit Channel](https://www.youtube.com/@lauriewired) |
 | zSecurity  | 350K  | English | [Visit Channel](https://www.youtube.com/c/zaborSecurity) |
 | Grant Collins  | 230K  | English | [Visit Channel](https://www.youtube.com/@GrantCollins) |
 | Cyberspatial  | 181K  | English | [Visit Channel](https://www.youtube.com/@Cyberspatial) |


### PR DESCRIPTION
## Summary
- Adds **LaurieWired** to the Cybersecurity category
- Channel by Laurie Kirk, a reverse engineer at Microsoft
- Content: malware analysis, reverse engineering (Android/cross-platform), binary exploitation, assembly programming
- ~429K subscribers, launched January 2023
- Placed between IppSec (400K) and zSecurity (350K) by subscriber count

## Test plan
- [ ] Verify channel link resolves to https://www.youtube.com/@lauriewired
- [ ] Confirm subscriber count and ordering within the Cybersecurity section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Cybersecurity section with a new channel entry including subscriber count and resource link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->