### PR TITLE
Add Ryan Peterman to Programming & Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 | Learn Code With Durgesh  | 120K  | Hindi | [Visit Channel](https://www.youtube.com/c/LearnCodeWithDurgesh) |
 | Automate the Boring Stuff  | 122K  | English | [Visit Channel](https://www.youtube.com/c/AutomatetheBoringStuff) |
 | Chris Sean  | 110K  | English | [Visit Channel](https://www.youtube.com/c/ChrisSean) |
+| Ryan Peterman  | 25K  | English | [Visit Channel](https://www.youtube.com/@RyanLPeterman) |
 | Code with Ahsan  | 8K  | Urdu | [Visit Channel](https://www.youtube.com/c/CodewithAhsan) |
 
 ## AI & Automation


### PR DESCRIPTION
## Summary
- Adds **Ryan Peterman** to the Programming & Coding category
- Former Staff Engineer at Instagram/Meta, now a software engineering educator
- Content: engineering career advice, staff/senior engineer journeys, interviews with engineers at top companies (Meta, Google, Anthropic, OpenAI)
- ~25K subscribers on YouTube (100K+ newsletter subscribers)
- Placed between Chris Sean (110K) and Code with Ahsan (8K) by subscriber count

## Test plan
- [ ] Verify channel link resolves to https://www.youtube.com/@RyanLPeterman
- [ ] Confirm subscriber count and ordering within the Programming & Coding section